### PR TITLE
INF-4215 fix: cant use matrix when calling shared workflow

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -2,13 +2,26 @@ name: Verify PR - Terraform Lint
 on:
   workflow_call:
     inputs:
-      working-directory:
+      directories:
         required: true
         type: string
 
 jobs:
+  get-directories: # Job that list subdirectories
+    runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.set-directories.outputs.directories }} # generate output name dir by using inner step output
+    steps:
+      - name: Set Directories
+        id: set-directories # Give it an id to handle to get step outputs in the outputs key above
+        run: echo "::set-output name=directories::$(echo ${{ input.directories }} | jq -R -c 'split(",")')
+        # Define step output named dir base on ls command transformed to JSON thanks to jq
   fmt:
     runs-on: ubuntu-latest
+    needs: [get-directories] # Depends on previous job
+    strategy:
+      matrix:
+        directory: ${{ fromJson(needs.get-directories.outputs.directories) }} # List matrix strategy from directories dynamically
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,9 +33,13 @@ jobs:
 
       - name: Terraform Format
         run: terraform fmt -check
-        working-directory: ${{ inputs.working-directory }}
+        working-directory: ${{ matrix.directory }}
   tfsec:
     runs-on: ubuntu-latest
+    needs: [get-directories] # Depends on previous job
+    strategy:
+      matrix:
+        directory: ${{ fromJson(needs.get-directories.outputs.directories) }} # List matrix strategy from directories dynamically
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -31,35 +48,50 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: invitation-homes/terraform-linting-rules
-          path: ${{ inputs.working-directory }}/.tfsec
+          path: ${{ matrix.directory }}/.tfsec
           token: ${{ secrets.GH_REPO_ACCESS_TOKEN }}
 
       - name: tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@main
         with:
           github_token: ${{ github.token }}
+          working_directory: ${{ matrix.directory }}
   tflint:
     runs-on: ubuntu-latest
+    needs: [get-directories] # Depends on previous job
+    strategy:
+      matrix:
+        directory: ${{ fromJson(needs.get-directories.outputs.directories) }} # List matrix strategy from directories dynamically
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: "Check for TF files"
+        id: check-tf-files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ matrix.directory }}/*.tf"
+
       - name: Get Rules
+        if: steps.check-tf-files.outputs.files_exists == 'true'
         uses: actions/checkout@v3
         with:
           repository: invitation-homes/terraform-linting-rules
-          path: ${{ inputs.working-directory }}/.tfsec
+          path: ${{ matrix.directory }}/.tfsec
           token: ${{ secrets.GH_REPO_ACCESS_TOKEN }}
-          
+
       - uses: terraform-linters/setup-tflint@v1
+        if: steps.check-tf-files.outputs.files_exists == 'true'
         name: Setup TFLint
         with:
           tflint_version: latest
 
       - name: Initialize TFLint
-        working-directory: ${{ inputs.working-directory }}
-        run: tflint --init --config=${{ inputs.working-directory }}/.tfsec/.tflint.hcl
+        if: steps.check-tf-files.outputs.files_exists == 'true'
+        working-directory: ${{ matrix.directory  }}
+        run: tflint --init --config=.tfsec/.tflint.hcl
 
       - name: Run TFLint
-        working-directory: ${{ inputs.working-directory }}
-        run: tflint --init --config=${{ inputs.working-directory }}/.tfsec/.tflint.hcl
+        if: steps.check-tf-files.outputs.files_exists == 'true'
+        working-directory: ${{ matrix.directory  }}
+        run: tflint -f compact --config=.tfsec/.tflint.hcl


### PR DESCRIPTION
Now takes a string of comma separated directories to run against

jira: INF-4215