### PR TITLE
feat: test kics gh action

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Terraform fmt Status
         if: steps.fmt.outcome == 'failure'
         run: exit 1
-  tfsec:
+  kics:
     runs-on: ubuntu-latest
     needs: [set-directories]
     strategy:
@@ -92,81 +92,23 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: invitation-homes/terraform-linting-rules
-          path: ${{ matrix.directory }}/.tfsec
+          path: ${{ matrix.directory }}/assets/queries
           token: ${{ secrets.GH_REPO_ACCESS_TOKEN }}
 
-      - name: Install tfsec
-        if: steps.check-tf-files.outputs.files_exists == 'true'
-        run: curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-      
-      - name: Run tfsec
-        id: tfsec
-        if: steps.check-tf-files.outputs.files_exists == 'true'
-        working-directory: ${{ matrix.directory }}
+      - name: Run KICS
+        uses: checkmarx/kics-github-action@v1.6
+        with:
+          path: ${{ matrix.directory }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          output_path: kics_results/
+          exclude_severities: 'info,low'
+          ignore_on_exit: results
+          enable_comments: true
+
+      - name: Display KICS results
         run: |
-          # run tfsec and write the results to a results.json file
-          tfsec --concise-output --minimum-severity medium --format json --out results.json
-          result_code=${PIPESTATUS[0]}
-          
-          # exit with the pertinent error code only after we have exposed the output for later steps 
-          exit $result_code
-        continue-on-error: true
-      
-      - name: Read results.json
-        id: read-results
-        if: steps.check-tf-files.outputs.files_exists == 'true'
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ${{ matrix.directory }}/results.json
+          cat kics_results/results.json
 
-      - name: Echo results.json
-        if: steps.read-results.outcome == 'success'
-        id: results
-        run: echo "${{ steps.read-results.outputs.content }}"
-      
-      - name: Comment on PR
-        uses: actions/github-script@v6
-        if: steps.tfsec.outcome == 'failure'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // parse contents of results.json to a JS object, and extract pertinent information from it into a PR comment
-            var getFilename = function (str) {
-                return str.substring(str.lastIndexOf('/')+1)
-            }
-
-            const jsonObj = JSON.parse(`${{ steps.read-results.outputs.content }}`)
-
-            let comment = ""
-
-            for (const violation of jsonObj.results) {
-
-              let filename = getFilename(violation.location.filename)
-              let s = `${filename}:${violation.location.start_line}-${violation.location.end_line}: ${violation.resolution}, ${violation.severity}\n`
-
-              comment += s
-            }
-
-            const output = `#### tfsec 📖\`${{ steps.tfsec.outcome }}\`
-
-            <details><summary>Directory: ${{ matrix.directory }}</summary>
-
-            \`\`\`
-            ${comment}
-            \`\`\`
-
-            </details>`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
-
-      - name: tfsec Status
-        if: steps.tfsec.outcome == 'failure'
-        run: exit 1
   tflint:
     runs-on: ubuntu-latest
     needs: [set-directories]


### PR DESCRIPTION
jira: CP-665

This is a proof of concept demonstrating the KICS GitHub action is functional.

Scan features:
- Output of scan goes to a kics_results/results.json file
- Only medium and high severities are considered
- If there is a failure, it does not prevent the pipeline from exiting
- If there is a vulnerability, a comment will be posted on the PR
- After scanning, the results are added as annotations in the PR

This is just a start and we can expand functionality by pulling in custom made queries from a directory. These additions can be handled in future PRs. 